### PR TITLE
Remove ignition.firstboot=1 from grub during early boot

### DIFF
--- a/configs/common/systemd/ocne-disable-ignition.service
+++ b/configs/common/systemd/ocne-disable-ignition.service
@@ -2,6 +2,7 @@
 Description=Disable Ignition
 Requires=ignition-complete.target
 After=ignition-complete.target
+After=boot.mount
 
 [Service]
 Type=oneshot

--- a/configs/common/systemd/ocne-disable-ignition.service
+++ b/configs/common/systemd/ocne-disable-ignition.service
@@ -6,6 +6,7 @@ After=ignition-complete.target
 [Service]
 Type=oneshot
 ExecStart=rpm-ostree kargs --delete-if-present=ignition.firstboot=1
+ExecStart=sh -c "grubby --remove-args=ignition.firstboot=1 --update-kernel=/boot$(cat /proc/cmdline  | cut -d' ' -f1 | cut -d')' -f2)"
 RemainAfterExit=no
 
 [Install]


### PR DESCRIPTION
Adds an extra ExecStart to the service that uses grubby to remove the argument from the current running kernel

Here's what is happening
```
# A kernel command line looks like this, with the booted kernel at the front
# cat /proc/cmdline 
BOOT_IMAGE=(hd0,gpt2)/ostree/ock-890d615bbb6810d2916b418e5486f37cd4aa262ade20e8937b0d21a0fe381614/vmlinuz-5.15.0-302.167.6.el8uek.x86_64 rw ip=dhcp rd.neednet=1 ignition.platform.id=qemu crashkernel=auto console=ttyS0 root=UUID=f0454530-5baf-41a3-8d21-fa45e741127e ostree=/ostree/boot.1/ock/890d615bbb6810d2916b418e5486f37cd4aa262ade20e8937b0d21a0fe381614/0 rd.timeout=120

# This takes the value, cuts off all but the first argument, and then takes all the text after the ')' in 'BOOT_IMAGE=(hd0,gpt2)'.
# cat /proc/cmdline | cut -d' ' -f1 | cut -d')' -f2
/ostree/ock-890d615bbb6810d2916b418e5486f37cd4aa262ade20e8937b0d21a0fe381614/vmlinuz-5.15.0-302.167.6.el8uek.x86_64

# Then /boot gets stuck on the front because that is what (hd0,gpt2) refers to.  This is not the most generic
# solution, but its basically guaranteed that the boot partition where the kernel is sourced gets mounted to /boot
# echo /boot$(cat /proc/cmdline  | cut -d' ' -f1 | cut -d')' -f2) 
/boot/ostree/ock-890d615bbb6810d2916b418e5486f37cd4aa262ade20e8937b0d21a0fe381614/vmlinuz-5.15.0-302.167.6.el8uek.x86_64
```
This value gets passed to grubby as the kernel to modify, removing the argument.

Looking at the running kernel rather than some default kernel or something else makes the service more tolerant to esoteric deployments where multiple operating systems may be sitting next to one another sharing the OCK boot partition.