### PR TITLE
Ensure /etc/machine-id is not created and add a presets file for OCNE services

### DIFF
--- a/configs/common/systemd/80-ocne.preset
+++ b/configs/common/systemd/80-ocne.preset
@@ -1,0 +1,8 @@
+enable ocne-disable-ignition.service
+enable ocne.service
+enable ocne-prune.service
+enable ocne-update.service
+enable ocne-image-cleanup.service
+enable usr-lib-opt-cni-bin.mount
+disable ocne-nginx.service
+disable keepalived.service

--- a/configs/config-1.26/manifest.yaml
+++ b/configs/config-1.26/manifest.yaml
@@ -3,6 +3,7 @@ automatic-version-prefix: "1.26"
 
 documentation: false
 boot-location: modules
+machineid-compat: false
 
 repos:
 - ol8_baseos_latest

--- a/configs/config-1.26/ocne.yaml
+++ b/configs/config-1.26/ocne.yaml
@@ -13,6 +13,7 @@ packages:
 - openssh-clients
 
 add-files:
+- ["systemd/80-ocne.preset", "/usr/lib/systemd/system-preset/80-ocne.preset"]
 - ["systemd/update-ca-trust.service", "/usr/lib/systemd/system/update-ca-trust.service"]
 - ["systemd/update-ca-trust.path", "/usr/lib/systemd/system/update-ca-trust.path"]
 - ["systemd/ocne-disable-ignition.service", "/usr/lib/systemd/system/ocne-disable-ignition.service"]
@@ -43,16 +44,6 @@ add-files:
 - ["dracut-modules/make-rootfs.service", "/usr/lib/dracut/modules.d/35ocne/make-rootfs.service"]
 - ["dracut-modules/move-gpt-header.sh", "/usr/lib/dracut/modules.d/35ocne/move-gpt-header.sh"]
 - ["dracut-modules/move-gpt-header.service", "/usr/lib/dracut/modules.d/35ocne/move-gpt-header.service"]
-
-units:
-- ocne-disable-ignition.service
-- ocne.service
-- ocne-prune.service
-- ocne-update.service
-- ocne-image-cleanup.service
-- ocne-nginx.service
-- keepalived.service
-- usr-lib-opt-cni-bin.mount
 
 postprocess:
 - rm /etc/cni/net.d/100-crio-bridge.conf

--- a/configs/config-1.27/manifest.yaml
+++ b/configs/config-1.27/manifest.yaml
@@ -3,6 +3,7 @@ automatic-version-prefix: "1.27"
 
 documentation: false
 boot-location: modules
+machineid-compat: false
 
 repos:
 - ol8_baseos_latest

--- a/configs/config-1.27/ocne.yaml
+++ b/configs/config-1.27/ocne.yaml
@@ -13,6 +13,7 @@ packages:
 - openssh-clients
 
 add-files:
+- ["systemd/80-ocne.preset", "/usr/lib/systemd/system-preset/80-ocne.preset"]
 - ["systemd/update-ca-trust.service", "/usr/lib/systemd/system/update-ca-trust.service"]
 - ["systemd/update-ca-trust.path", "/usr/lib/systemd/system/update-ca-trust.path"]
 - ["systemd/ocne-disable-ignition.service", "/usr/lib/systemd/system/ocne-disable-ignition.service"]
@@ -43,16 +44,6 @@ add-files:
 - ["dracut-modules/make-rootfs.service", "/usr/lib/dracut/modules.d/35ocne/make-rootfs.service"]
 - ["dracut-modules/move-gpt-header.sh", "/usr/lib/dracut/modules.d/35ocne/move-gpt-header.sh"]
 - ["dracut-modules/move-gpt-header.service", "/usr/lib/dracut/modules.d/35ocne/move-gpt-header.service"]
-
-units:
-- ocne-disable-ignition.service
-- ocne.service
-- ocne-prune.service
-- ocne-update.service
-- ocne-image-cleanup.service
-- ocne-nginx.service
-- keepalived.service
-- usr-lib-opt-cni-bin.mount
 
 postprocess:
 - rm /etc/cni/net.d/100-crio-bridge.conf

--- a/configs/config-1.28/manifest.yaml
+++ b/configs/config-1.28/manifest.yaml
@@ -3,6 +3,7 @@ automatic-version-prefix: "1.28"
 
 documentation: false
 boot-location: modules
+machineid-compat: false
 
 repos:
 - ol8_baseos_latest

--- a/configs/config-1.28/ocne.yaml
+++ b/configs/config-1.28/ocne.yaml
@@ -14,6 +14,7 @@ packages:
 - openssh-clients
 
 add-files:
+- ["systemd/80-ocne.preset", "/usr/lib/systemd/system-preset/80-ocne.preset"]
 - ["systemd/update-ca-trust.service", "/usr/lib/systemd/system/update-ca-trust.service"]
 - ["systemd/update-ca-trust.path", "/usr/lib/systemd/system/update-ca-trust.path"]
 - ["systemd/ocne-disable-ignition.service", "/usr/lib/systemd/system/ocne-disable-ignition.service"]
@@ -44,16 +45,6 @@ add-files:
 - ["dracut-modules/make-rootfs.service", "/usr/lib/dracut/modules.d/35ocne/make-rootfs.service"]
 - ["dracut-modules/move-gpt-header.sh", "/usr/lib/dracut/modules.d/35ocne/move-gpt-header.sh"]
 - ["dracut-modules/move-gpt-header.service", "/usr/lib/dracut/modules.d/35ocne/move-gpt-header.service"]
-
-units:
-- ocne-disable-ignition.service
-- ocne.service
-- ocne-prune.service
-- ocne-update.service
-- ocne-image-cleanup.service
-- ocne-nginx.service
-- keepalived.service
-- usr-lib-opt-cni-bin.mount
 
 postprocess:
 - rm /etc/cni/net.d/100-crio-bridge.conf

--- a/configs/config-1.29/manifest.yaml
+++ b/configs/config-1.29/manifest.yaml
@@ -3,6 +3,7 @@ automatic-version-prefix: "1.29"
 
 documentation: false
 boot-location: modules
+machineid-compat: false
 
 repos:
 - ol8_baseos_latest

--- a/configs/config-1.29/ocne.yaml
+++ b/configs/config-1.29/ocne.yaml
@@ -13,6 +13,7 @@ packages:
 - openssh-clients
 
 add-files:
+- ["systemd/80-ocne.preset", "/usr/lib/systemd/system-preset/80-ocne.preset"]
 - ["systemd/update-ca-trust.service", "/usr/lib/systemd/system/update-ca-trust.service"]
 - ["systemd/update-ca-trust.path", "/usr/lib/systemd/system/update-ca-trust.path"]
 - ["systemd/ocne-disable-ignition.service", "/usr/lib/systemd/system/ocne-disable-ignition.service"]
@@ -43,16 +44,6 @@ add-files:
 - ["dracut-modules/make-rootfs.service", "/usr/lib/dracut/modules.d/35ocne/make-rootfs.service"]
 - ["dracut-modules/move-gpt-header.sh", "/usr/lib/dracut/modules.d/35ocne/move-gpt-header.sh"]
 - ["dracut-modules/move-gpt-header.service", "/usr/lib/dracut/modules.d/35ocne/move-gpt-header.service"]
-
-units:
-- ocne-disable-ignition.service
-- ocne.service
-- ocne-prune.service
-- ocne-update.service
-- ocne-image-cleanup.service
-- ocne-nginx.service
-- keepalived.service
-- usr-lib-opt-cni-bin.mount
 
 postprocess:
 - rm /etc/cni/net.d/100-crio-bridge.conf

--- a/configs/config-1.30/manifest.yaml
+++ b/configs/config-1.30/manifest.yaml
@@ -3,6 +3,7 @@ automatic-version-prefix: "1.30"
 
 documentation: false
 boot-location: modules
+machineid-compat: false
 
 repos:
 - ol8_baseos_latest

--- a/configs/config-1.30/ocne.yaml
+++ b/configs/config-1.30/ocne.yaml
@@ -13,6 +13,7 @@ packages:
 - openssh-clients
 
 add-files:
+- ["systemd/80-ocne.preset", "/usr/lib/systemd/system-preset/80-ocne.preset"]
 - ["systemd/update-ca-trust.service", "/usr/lib/systemd/system/update-ca-trust.service"]
 - ["systemd/update-ca-trust.path", "/usr/lib/systemd/system/update-ca-trust.path"]
 - ["systemd/ocne-disable-ignition.service", "/usr/lib/systemd/system/ocne-disable-ignition.service"]
@@ -43,17 +44,6 @@ add-files:
 - ["dracut-modules/make-rootfs.service", "/usr/lib/dracut/modules.d/35ocne/make-rootfs.service"]
 - ["dracut-modules/move-gpt-header.sh", "/usr/lib/dracut/modules.d/35ocne/move-gpt-header.sh"]
 - ["dracut-modules/move-gpt-header.service", "/usr/lib/dracut/modules.d/35ocne/move-gpt-header.service"]
-
-
-units:
-- ocne-disable-ignition.service
-- ocne.service
-- ocne-prune.service
-- ocne-update.service
-- ocne-image-cleanup.service
-- ocne-nginx.service
-- keepalived.service
-- usr-lib-opt-cni-bin.mount
 
 postprocess:
 - rm /etc/cni/net.d/100-crio-bridge.conf


### PR DESCRIPTION
For all versions, set machineid-compat to false.  This prevents rpm-ostree from generating an empty file at /etc/machine-id, which in turn allows systemd to evaluate presets.  This options is not compatible with the "units" list.  Convert that to a preset file with lower priority than the one generated by ignition.