### PR TITLE
Split udevadm into two commands

### DIFF
--- a/configs/common/dracut-modules/move-gpt-header.sh
+++ b/configs/common/dracut-modules/move-gpt-header.sh
@@ -13,4 +13,5 @@ DISK="${ROOT_DEVICES[0]}"
 
 # Move the GPT header to the end of the disk
 sgdisk -e "${DISK}"
-udevadm trigger --settle
+udevadm trigger
+udevadm settle

--- a/configs/common/dracut-modules/move-gpt-header.sh
+++ b/configs/common/dracut-modules/move-gpt-header.sh
@@ -14,4 +14,4 @@ DISK="${ROOT_DEVICES[0]}"
 # Move the GPT header to the end of the disk
 sgdisk -e "${DISK}"
 udevadm trigger
-udevadm settle
+udevadm settle --timeout=300

--- a/configs/common/dracut-modules/partition-info.sh
+++ b/configs/common/dracut-modules/partition-info.sh
@@ -6,7 +6,8 @@ set -e
 set -x
 
 # Do the level best to have a calm device tree.
-udevadm trigger --settle
+udevadm trigger
+udevadm settle
 
 ROOT="$1"
 ROOT_DEVICE=

--- a/configs/common/dracut-modules/partition-info.sh
+++ b/configs/common/dracut-modules/partition-info.sh
@@ -7,7 +7,7 @@ set -x
 
 # Do the level best to have a calm device tree.
 udevadm trigger
-udevadm settle
+udevadm settle --timeout=300
 
 ROOT="$1"
 ROOT_DEVICE=


### PR DESCRIPTION
A bug occurs on bare metal machines due to udevadm trigger --settle. It causes BM installs to hang indefinitely. This PR is to fix this issue.