### PR TITLE
Add Kubernetes 1.31

### DIFF
--- a/configs/config-1.26/base.yaml
+++ b/configs/config-1.26/base.yaml
@@ -20,7 +20,7 @@ packages:
 - socat net-tools bind-utils
 - nmstate
 - ipcalc
-- skopeo-1.14.3
+- skopeo
 - cloud-utils-growpart
 - shim
 - efibootmgr

--- a/configs/config-1.27/base.yaml
+++ b/configs/config-1.27/base.yaml
@@ -20,7 +20,7 @@ packages:
 - socat net-tools bind-utils
 - nmstate
 - ipcalc
-- skopeo-1.14.3
+- skopeo
 - cloud-utils-growpart
 - shim
 - efibootmgr

--- a/configs/config-1.28/base.yaml
+++ b/configs/config-1.28/base.yaml
@@ -20,7 +20,7 @@ packages:
 - socat net-tools bind-utils
 - nmstate
 - ipcalc
-- skopeo-1.14.3
+- skopeo
 - cloud-utils-growpart
 - shim
 - efibootmgr

--- a/configs/config-1.29/base.yaml
+++ b/configs/config-1.29/base.yaml
@@ -20,7 +20,7 @@ packages:
 - socat net-tools bind-utils
 - nmstate
 - ipcalc
-- skopeo-1.14.3
+- skopeo
 - cloud-utils-growpart
 - shim
 - efibootmgr

--- a/configs/config-1.30/base.yaml
+++ b/configs/config-1.30/base.yaml
@@ -20,7 +20,7 @@ packages:
 - socat net-tools bind-utils
 - nmstate
 - ipcalc
-- skopeo-1.14.3
+- skopeo
 - cloud-utils-growpart
 - shim
 - efibootmgr

--- a/configs/config-1.31/base.yaml
+++ b/configs/config-1.31/base.yaml
@@ -1,0 +1,36 @@
+packages:
+- ostree
+- rpm-ostree
+- kernel-uek-core
+- xfsprogs
+- e2fsprogs
+- chrony
+- polkit
+- systemd-container
+- containernetworking-plugins podman-plugins dnsmasq
+- iptables
+- attr
+- openssl
+- ncurses
+- kbd
+- irqbalance
+- nss-altfiles
+- NetworkManager hostname
+- iproute
+- socat net-tools bind-utils
+- nmstate
+- ipcalc
+- skopeo-1.14.3
+- cloud-utils-growpart
+- shim
+- efibootmgr
+- iscsi-initiator-utils
+- kernel-uek-modules
+
+packages-x86_64:
+- grub2-efi-x64
+- grub2-tools-efi
+
+packages-aarch64:
+- grub2-efi-aa64
+- grub2-tools

--- a/configs/config-1.31/base.yaml
+++ b/configs/config-1.31/base.yaml
@@ -20,7 +20,7 @@ packages:
 - socat net-tools bind-utils
 - nmstate
 - ipcalc
-- skopeo-1.14.3
+- skopeo
 - cloud-utils-growpart
 - shim
 - efibootmgr

--- a/configs/config-1.31/config.yaml
+++ b/configs/config-1.31/config.yaml
@@ -1,0 +1,24 @@
+add-files:
+- ["fs/etc/modprobe.d/blacklist.conf", "/etc/modprobe.d/blacklist.conf"]
+- ["fs/etc/systemd/coredump.conf", "/etc/systemd/coredump.conf"]
+- ["fs/etc/sudoers", "/etc/sudoers"]
+- ["fs/etc/ssh/sshd_config", "/etc/systemd/system/sshd_config"]
+- ["fs/etc/pam.d/su", "/etc/pam.d/su"]
+- ["fs/etc/security/faillock.conf", "/etc/security/faillock.conf"]
+- ["fs/etc/security/pwquality.conf", "/etc/security/pwquality.conf"]
+- ["fs/etc/security/pwhistory.conf", "/etc/security/pwhistory.conf"]
+- ["fs/etc/sysctl.d/30-harden.conf", "/etc/sysctl.d/30-harden.conf"]
+- ["fs/etc/sysconfig/nftables.conf", "/etc/sysconfig/nftables.conf"]
+- ["fs/etc/nftables/kube.nft", "/etc/nftables/kube.nft"]
+- ["fs/etc/nftables/kube-svcs.nft", "/etc/nftables/kube-svcs.nft"]
+- ["fs/etc/nftables/main.nft", "/etc/nftables/main.nft"]
+- ["fs/etc/profile.d/harden.sh", "/etc/profile.d/harden.sh"]
+- ["fs/etc/audit/auditd.conf", "/etc/audit/auditd.conf"]
+- ["fs/etc/audit/rules.d/50-harden.rules", "/etc/audit/rules.d/50-harden.rules"]
+- ["fs/etc/audit/rules.d/99-finalize.rules", "/etc/audit/rules.d/99-finalize.rules"]
+
+postprocess:
+- chmod 000 /etc/shadow
+- chmod 000 /etc/shadow-
+- chmod 000 /etc/gshadow
+- chmod 000 /etc/gshadow-

--- a/configs/config-1.31/dracut-modules
+++ b/configs/config-1.31/dracut-modules
@@ -1,0 +1,1 @@
+../common/dracut-modules/

--- a/configs/config-1.31/files/check-node-health.sh
+++ b/configs/config-1.31/files/check-node-health.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+#
+# Copyright (c) 2024, Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+kubelet_status_exit_code=1
+
+# Get the kubelet status
+get_kubelet_status() {
+    systemctl status kubelet &> /dev/null
+    kubelet_status_exit_code=$?
+}
+
+# Display kubelet status using systemctl
+display_kubelet_status() {
+    printf "\n"
+    get_kubelet_status
+  
+  if [[ $kubelet_status_exit_code -eq 0 ]]; then
+    echo "Kubelet Status: Running"
+  else
+    echo "Kubelet Status: Not Running"
+  fi
+}
+
+# Display node disk and memory information
+display_node_info() {
+    printf "\n"
+    free -h | grep 'Mem:' | awk '{print "Memory Usage: " $3 "/" $2}'
+    printf "\n"
+    echo "Disk Usage:"
+    df -h
+}
+
+main() {
+
+    get_kubelet_status
+    if [ $kubelet_status_exit_code -ne 0 ]; then
+        echo -e "Node Information:"
+        display_kubelet_status
+        display_node_info
+    fi 
+}
+
+main
+exit $kubelet_status_exit_code

--- a/configs/config-1.31/files/crio.conf
+++ b/configs/config-1.31/files/crio.conf
@@ -1,0 +1,36 @@
+[crio]
+  [crio.api]
+  [crio.image]
+    pause_image = "container-registry.oracle.com/olcne/pause:3.10"
+    pause_image_auth_file = "/run/containers/0/auth.json"
+  [crio.metrics]
+  [crio.network]
+    plugin_dirs = ["/opt/cni/bin"]
+  [crio.nri]
+  [crio.runtime]
+    default_runtime = "runc"
+    cgroup_manager = "systemd"
+    conmon = "/usr/bin/conmon"
+    conmon_cgroup = "system.slice"
+    manage_network_ns_lifecycle = true
+    manage_ns_lifecycle = true
+    selinux = true
+    [crio.runtime.runtimes]
+      [crio.runtime.runtimes.kata]
+        runtime_path = "/usr/bin/containerd-shim-kata-v2"
+        runtime_type = "vm"
+        runtime_root = "/run/vc"
+        privileged_without_host_devices = true
+      [crio.runtime.runtimes.runc]
+        allowed_annotations = ["io.containers.trace-syscall"]
+        monitor_cgroup = "system.slice"
+        monitor_env = ["PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"]
+        monitor_exec_cgroup = ""
+        monitor_path = "/usr/bin/conmon"
+        privileged_without_host_devices = false
+        runtime_config_path = ""
+        runtime_path = ""
+        runtime_root = "/run/runc"
+        runtime_type = "oci"
+  [crio.stats]
+  [crio.tracing]

--- a/configs/config-1.31/files/kubeadm-default.conf
+++ b/configs/config-1.31/files/kubeadm-default.conf
@@ -24,17 +24,17 @@ networking:
   serviceSubnet: 10.96.0.0/12
   podSubnet: 10.244.0.0/16
 imageRepository: container-registry.oracle.com/olcne
-kubernetesVersion: 1.30.3
+kubernetesVersion: 1.31.5
 etcd:
   local:
     imageRepository: container-registry.oracle.com/olcne
-    imageTag: 3.5.12
+    imageTag: 3.5.18
     extraArgs:
       listen-metrics-urls: http://0.0.0.0:2381
     peerCertSANs: []
 dns:
   imageRepository: container-registry.oracle.com/olcne
-  imageTag: v1.11.1
+  imageTag: current
 ---
 apiVersion: kubeproxy.config.k8s.io/v1alpha1
 kind: KubeProxyConfiguration

--- a/configs/config-1.31/files/kubeadm-default.conf
+++ b/configs/config-1.31/files/kubeadm-default.conf
@@ -1,0 +1,42 @@
+apiVersion: kubeadm.k8s.io/v1beta3
+kind: InitConfiguration
+certificateKey: 34a7a99924b249364a53f0cd2af07893c39549f3fa5ad0efafb01b193f7868fe
+nodeRegistration:
+  kubeletExtraArgs:
+    tls-min-version: VersionTLS12
+    address: 0.0.0.0
+    authorization-mode: AlwaysAllow
+---
+apiVersion: kubeadm.k8s.io/v1beta3
+kind: ClusterConfiguration
+apiServer:
+  extraArgs:
+    tls-min-version: VersionTLS12
+controllerManager:
+  extraArgs:
+    tls-min-version: VersionTLS12
+    bind-address: 0.0.0.0
+scheduler:
+  extraArgs:
+    tls-min-version: VersionTLS12
+    bind-address: 0.0.0.0
+networking:
+  serviceSubnet: 10.96.0.0/12
+  podSubnet: 10.244.0.0/16
+imageRepository: container-registry.oracle.com/olcne
+kubernetesVersion: 1.30.3
+etcd:
+  local:
+    imageRepository: container-registry.oracle.com/olcne
+    imageTag: 3.5.12
+    extraArgs:
+      listen-metrics-urls: http://0.0.0.0:2381
+    peerCertSANs: []
+dns:
+  imageRepository: container-registry.oracle.com/olcne
+  imageTag: v1.11.1
+---
+apiVersion: kubeproxy.config.k8s.io/v1alpha1
+kind: KubeProxyConfiguration
+mode: iptables
+metricsBindAddress: 0.0.0.0:10249

--- a/configs/config-1.31/files/rescue.sh
+++ b/configs/config-1.31/files/rescue.sh
@@ -1,0 +1,12 @@
+#! /bin/bash
+#
+# Copyright (c) 2024, Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+/usr/bin/check-node-health.sh
+
+if [ $? -ne 0 ]; then
+	bash
+else
+	sudo cat /etc/kubernetes/admin.conf
+fi

--- a/configs/config-1.31/files/storage.conf
+++ b/configs/config-1.31/files/storage.conf
@@ -1,0 +1,237 @@
+# This file is the configuration file for all tools
+# that use the containers/storage library. The storage.conf file
+# overrides all other storage.conf files. Container engines using the
+# container/storage library do not inherit fields from other storage.conf
+# files.
+#
+#  Note: The storage.conf file overrides other storage.conf files based on this precedence:
+#      /usr/containers/storage.conf
+#      /etc/containers/storage.conf
+#      $HOME/.config/containers/storage.conf
+#      $XDG_CONFIG_HOME/containers/storage.conf (If XDG_CONFIG_HOME is set)
+# See man 5 containers-storage.conf for more information
+# The "container storage" table contains all of the server options.
+[storage]
+
+# Default Storage Driver, Must be set for proper operation.
+driver = "overlay"
+
+# Temporary storage location
+runroot = "/run/containers/storage"
+
+# Primary Read/Write location of container storage
+# When changing the graphroot location on an SELINUX system, you must
+# ensure  the labeling matches the default locations labels with the
+# following commands:
+# semanage fcontext -a -e /var/lib/containers/storage /NEWSTORAGEPATH
+# restorecon -R -v /NEWSTORAGEPATH
+graphroot = "/var/lib/containers/storage"
+
+
+# Storage path for rootless users
+#
+# rootless_storage_path = "$HOME/.local/share/containers/storage"
+
+# Transient store mode makes all container metadata be saved in temporary storage
+# (i.e. runroot above). This is faster, but doesn't persist across reboots.
+# transient_store = true
+
+[storage.options]
+# Storage options to be passed to underlying storage drivers
+
+# AdditionalImageStores is used to pass paths to additional Read/Only image stores
+# Must be comma separated list.
+additionalimagestores = [
+  "/usr/ock/containers"
+]
+
+# Allows specification of how storage is populated when pulling images. This
+# option can speed the pulling process of images compressed with format
+# zstd:chunked. Containers/storage looks for files within images that are being
+# pulled from a container registry that were previously pulled to the host.  It
+# can copy or create a hard link to the existing file when it finds them,
+# eliminating the need to pull them from the container registry. These options
+# can deduplicate pulling of content, disk storage of content and can allow the
+# kernel to use less memory when running containers.
+
+# containers/storage supports four keys
+#   * enable_partial_images="true" | "false"
+#     Tells containers/storage to look for files previously pulled in storage
+#     rather then always pulling them from the container registry.
+#   * use_hard_links = "false" | "true"
+#     Tells containers/storage to use hard links rather then create new files in
+#     the image, if an identical file already existed in storage.
+#   * ostree_repos = ""
+#     Tells containers/storage where an ostree repository exists that might have
+#     previously pulled content which can be used when attempting to avoid
+#     pulling content from the container registry
+pull_options = {enable_partial_images = "false", use_hard_links = "false", ostree_repos=""}
+
+# Remap-UIDs/GIDs is the mapping from UIDs/GIDs as they should appear inside of
+# a container, to the UIDs/GIDs as they should appear outside of the container,
+# and the length of the range of UIDs/GIDs.  Additional mapped sets can be
+# listed and will be heeded by libraries, but there are limits to the number of
+# mappings which the kernel will allow when you later attempt to run a
+# container.
+#
+# remap-uids = 0:1668442479:65536
+# remap-gids = 0:1668442479:65536
+
+# Remap-User/Group is a user name which can be used to look up one or more UID/GID
+# ranges in the /etc/subuid or /etc/subgid file.  Mappings are set up starting
+# with an in-container ID of 0 and then a host-level ID taken from the lowest
+# range that matches the specified name, and using the length of that range.
+# Additional ranges are then assigned, using the ranges which specify the
+# lowest host-level IDs first, to the lowest not-yet-mapped in-container ID,
+# until all of the entries have been used for maps.
+#
+# remap-user = "containers"
+# remap-group = "containers"
+
+# Root-auto-userns-user is a user name which can be used to look up one or more UID/GID
+# ranges in the /etc/subuid and /etc/subgid file.  These ranges will be partitioned
+# to containers configured to create automatically a user namespace.  Containers
+# configured to automatically create a user namespace can still overlap with containers
+# having an explicit mapping set.
+# This setting is ignored when running as rootless.
+# root-auto-userns-user = "storage"
+#
+# Auto-userns-min-size is the minimum size for a user namespace created automatically.
+# auto-userns-min-size=1024
+#
+# Auto-userns-max-size is the minimum size for a user namespace created automatically.
+# auto-userns-max-size=65536
+
+[storage.options.overlay]
+# ignore_chown_errors can be set to allow a non privileged user running with
+# a single UID within a user namespace to run containers. The user can pull
+# and use any image even those with multiple uids.  Note multiple UIDs will be
+# squashed down to the default uid in the container.  These images will have no
+# separation between the users in the container. Only supported for the overlay
+# and vfs drivers.
+#ignore_chown_errors = "false"
+
+# Inodes is used to set a maximum inodes of the container image.
+# inodes = ""
+
+# Path to an helper program to use for mounting the file system instead of mounting it
+# directly.
+#mount_program = "/usr/bin/fuse-overlayfs"
+
+# mountopt specifies comma separated list of extra mount options
+mountopt = "nodev,metacopy=on"
+
+# Set to skip a PRIVATE bind mount on the storage home directory.
+# skip_mount_home = "false"
+
+# Size is used to set a maximum size of the container image.
+# size = ""
+
+# ForceMask specifies the permissions mask that is used for new files and
+# directories.
+#
+# The values "shared" and "private" are accepted.
+# Octal permission masks are also accepted.
+#
+#  "": No value specified.
+#     All files/directories, get set with the permissions identified within the
+#     image.
+#  "private": it is equivalent to 0700.
+#     All files/directories get set with 0700 permissions.  The owner has rwx
+#     access to the files. No other users on the system can access the files.
+#     This setting could be used with networked based homedirs.
+#  "shared": it is equivalent to 0755.
+#     The owner has rwx access to the files and everyone else can read, access
+#     and execute them. This setting is useful for sharing containers storage
+#     with other users.  For instance have a storage owned by root but shared
+#     to rootless users as an additional store.
+#     NOTE:  All files within the image are made readable and executable by any
+#     user on the system. Even /etc/shadow within your image is now readable by
+#     any user.
+#
+#   OCTAL: Users can experiment with other OCTAL Permissions.
+#
+#  Note: The force_mask Flag is an experimental feature, it could change in the
+#  future.  When "force_mask" is set the original permission mask is stored in
+#  the "user.containers.override_stat" xattr and the "mount_program" option must
+#  be specified. Mount programs like "/usr/bin/fuse-overlayfs" present the
+#  extended attribute permissions to processes within containers rather than the
+#  "force_mask"  permissions.
+#
+# force_mask = ""
+
+[storage.options.thinpool]
+# Storage Options for thinpool
+
+# autoextend_percent determines the amount by which pool needs to be
+# grown. This is specified in terms of % of pool size. So a value of 20 means
+# that when threshold is hit, pool will be grown by 20% of existing
+# pool size.
+# autoextend_percent = "20"
+
+# autoextend_threshold determines the pool extension threshold in terms
+# of percentage of pool size. For example, if threshold is 60, that means when
+# pool is 60% full, threshold has been hit.
+# autoextend_threshold = "80"
+
+# basesize specifies the size to use when creating the base device, which
+# limits the size of images and containers.
+# basesize = "10G"
+
+# blocksize specifies a custom blocksize to use for the thin pool.
+# blocksize="64k"
+
+# directlvm_device specifies a custom block storage device to use for the
+# thin pool. Required if you setup devicemapper.
+# directlvm_device = ""
+
+# directlvm_device_force wipes device even if device already has a filesystem.
+# directlvm_device_force = "True"
+
+# fs specifies the filesystem type to use for the base device.
+# fs="xfs"
+
+# log_level sets the log level of devicemapper.
+# 0: LogLevelSuppress 0 (Default)
+# 2: LogLevelFatal
+# 3: LogLevelErr
+# 4: LogLevelWarn
+# 5: LogLevelNotice
+# 6: LogLevelInfo
+# 7: LogLevelDebug
+# log_level = "7"
+
+# min_free_space specifies the min free space percent in a thin pool require for
+# new device creation to succeed. Valid values are from 0% - 99%.
+# Value 0% disables
+# min_free_space = "10%"
+
+# mkfsarg specifies extra mkfs arguments to be used when creating the base
+# device.
+# mkfsarg = ""
+
+# metadata_size is used to set the `pvcreate --metadatasize` options when
+# creating thin devices. Default is 128k
+# metadata_size = ""
+
+# Size is used to set a maximum size of the container image.
+# size = ""
+
+# use_deferred_removal marks devicemapper block device for deferred removal.
+# If the thinpool is in use when the driver attempts to remove it, the driver
+# tells the kernel to remove it as soon as possible. Note this does not free
+# up the disk space, use deferred deletion to fully remove the thinpool.
+# use_deferred_removal = "True"
+
+# use_deferred_deletion marks thinpool device for deferred deletion.
+# If the device is busy when the driver attempts to delete it, the driver
+# will attempt to delete device every 30 seconds until successful.
+# If the program using the driver exits, the driver will continue attempting
+# to cleanup the next time the driver is used. Deferred deletion permanently
+# deletes the device and all data stored in device will be lost.
+# use_deferred_deletion = "True"
+
+# xfs_nospace_max_retries specifies the maximum number of retries XFS should
+# attempt to complete IO when ENOSPC (no space) error is returned by
+# underlying storage device.
+# xfs_nospace_max_retries = "0"

--- a/configs/config-1.31/fs
+++ b/configs/config-1.31/fs
@@ -1,0 +1,1 @@
+../common/fs

--- a/configs/config-1.31/image.yaml
+++ b/configs/config-1.31/image.yaml
@@ -1,0 +1,3 @@
+size: 10
+ignition-network-kcmdline: []
+compressor: xz

--- a/configs/config-1.31/ksplice-ol8.repo
+++ b/configs/config-1.31/ksplice-ol8.repo
@@ -1,0 +1,15 @@
+[ol8_ksplice]
+name=Ksplice for Oracle Linux $releasever ($basearch)
+baseurl=https://yum.oracle.com/repo/OracleLinux/OL8/ksplice/$basearch/
+gpgkey=https://yum.oracle.com/RPM-GPG-KEY-oracle-ol8
+gpgcheck=1
+enabled=1
+
+[ol8_x86_64_userspace_ksplice]
+name=Ksplice aware userspace packages for Oracle Linux $releasever ($basearch)
+baseurl=https://yum.oracle.com/repo/OracleLinux/OL8/userspace/ksplice/$basearch/
+gpgkey=https://yum.oracle.com/RPM-GPG-KEY-oracle-ol8
+gpgcheck=1
+enabled=0
+
+

--- a/configs/config-1.31/manifest.yaml
+++ b/configs/config-1.31/manifest.yaml
@@ -13,7 +13,6 @@ repos:
 - ol8_kvm_appstream
 - ol8_developer_EPEL
 - ol8_ocne
-- ocne_internal
 
 include:
 - base.yaml

--- a/configs/config-1.31/manifest.yaml
+++ b/configs/config-1.31/manifest.yaml
@@ -1,0 +1,34 @@
+ref: ock
+automatic-version-prefix: "1.31"
+
+documentation: false
+boot-location: modules
+machineid-compat: false
+
+repos:
+- ol8_baseos_latest
+- ol8_UEKR7
+- ol8_appstream
+- ol8_olcne19
+- ol8_kvm_appstream
+- ol8_developer_EPEL
+- ol8_ocne
+- ocne_internal
+
+include:
+- base.yaml
+- ux.yaml
+- ocne.yaml
+- removals.yaml
+- config.yaml
+
+readonly-executables: true
+
+preserve-passwd: false
+
+tmp-is-dir: true
+
+modules:
+  enable:
+    - container-tools:ol8
+    - virt:kvm_utils3

--- a/configs/config-1.31/mysql-ol8.repo
+++ b/configs/config-1.31/mysql-ol8.repo
@@ -1,0 +1,20 @@
+[ol8_MySQL80]
+name=MySQL 8.0 for Oracle Linux 8 ($basearch)
+baseurl=https://yum.oracle.com/repo/OracleLinux/OL8/MySQL80/community/$basearch/
+gpgkey=https://yum.oracle.com/RPM-GPG-KEY-oracle-ol8
+gpgcheck=1
+enabled=1
+
+[ol8_MySQL80_tools_community]
+name=MySQL 8.0 Tools Community for Oracle Linux 8 ($basearch)
+baseurl=https://yum.oracle.com/repo/OracleLinux/OL8/MySQL80/tools/community/$basearch/
+gpgkey=https://yum.oracle.com/RPM-GPG-KEY-oracle-ol8
+gpgcheck=1
+enabled=1
+
+[ol8_MySQL80_connectors_community]
+name=MySQL 8.0 Connectors Community for Oracle Linux 8 ($basearch)
+baseurl=https://yum.oracle.com/repo/OracleLinux/OL8/MySQL80/connectors/community/$basearch/
+gpgkey=https://yum.oracle.com/RPM-GPG-KEY-oracle-ol8
+gpgcheck=1
+enabled=1

--- a/configs/config-1.31/oci-included-ol8.repo
+++ b/configs/config-1.31/oci-included-ol8.repo
@@ -1,0 +1,8 @@
+[ol8_oci_included]
+name=Oracle Software for OCI users on Oracle Linux $releasever ($basearch)
+baseurl=https://yum.oracle.com/repo/OracleLinux/OL8/oci/included/$basearch/
+gpgkey=https://yum.oracle.com/RPM-GPG-KEY-oracle-ol8
+gpgcheck=1
+enabled=1
+
+

--- a/configs/config-1.31/oci-ol8.repo
+++ b/configs/config-1.31/oci-ol8.repo
@@ -1,0 +1,8 @@
+[ol8_oci]
+name=Oracle Linux $releasever OCI Packages ($basearch)
+baseurl=https://yum.oracle.com/repo/OracleLinux/OL8/oci/$basearch/
+gpgkey=https://yum.oracle.com/RPM-GPG-KEY-oracle-ol8
+gpgcheck=1
+enabled=1
+
+

--- a/configs/config-1.31/ocne.yaml
+++ b/configs/config-1.31/ocne.yaml
@@ -1,0 +1,52 @@
+packages:
+- kubelet-1.31.5
+- kubeadm-1.31.5
+- kubectl-1.31.5
+- kubernetes-imgs-1.31.5
+- podman
+- yq
+- ignition-2.16.2
+- keepalived
+- qemu-kvm-7.2.0
+- ocne-selinux
+- audit
+- openssh-clients
+
+add-files:
+- ["systemd/80-ocne.preset", "/usr/lib/systemd/system-preset/80-ocne.preset"]
+- ["systemd/update-ca-trust.service", "/usr/lib/systemd/system/update-ca-trust.service"]
+- ["systemd/update-ca-trust.path", "/usr/lib/systemd/system/update-ca-trust.path"]
+- ["systemd/ocne-disable-ignition.service", "/usr/lib/systemd/system/ocne-disable-ignition.service"]
+- ["systemd/ocne.service", "/usr/lib/systemd/system/ocne.service"]
+- ["systemd/ocne.sh", "/etc/ocne/ocne.sh"]
+- ["systemd/ocne-update.service", "/usr/lib/systemd/system/ocne-update.service"]
+- ["systemd/ocne-update.sh", "/etc/ocne/ocne-update.sh"]
+- ["systemd/ocne-image-cleanup.service", "/usr/lib/systemd/system/ocne-image-cleanup.service"]
+- ["systemd/ocne-image-cleanup.sh", "/etc/ocne/ocne-image-cleanup.sh"]
+- ["systemd/ocne-reset.service", "/usr/lib/systemd/system/ocne-reset.service"]
+- ["systemd/ocne-reset.sh", "/etc/ocne/ocne-reset.sh"]
+- ["systemd/ocne-kube-update.sh", "/etc/ocne/ocne-kube-update.sh"]
+- ["systemd/ocne-kubeadm-upgrade.sh", "/etc/ocne/ocne-kubeadm-upgrade.sh"]
+- ["systemd/ocne-prune.service", "/usr/lib/systemd/system/ocne-prune.service"]
+- ["systemd/ocne-prune.sh", "/etc/ocne/ocne-prune.sh"]
+- ["systemd/kube-update.conf", "/etc/systemd/system/kubelet.service.d/kube-update.conf"]
+- ["files/crio.conf", "/etc/crio/crio.conf"]
+- ["files/kubeadm-default.conf", "/etc/ocne/kubeadm-default.conf"]
+- ["files/check-node-health.sh", "/usr/bin/check-node-health.sh"]
+- ["files/rescue.sh", "/usr/bin/rescue.sh"]
+- ["files/storage.conf", "/etc/containers/storage.conf"]
+- ["systemd/usr-lib-opt-cni-bin.mount", "/etc/systemd/system/usr-lib-opt-cni-bin.mount"]
+- ["dracut-modules/module-setup.sh", "/usr/lib/dracut/modules.d/35ocne/module-setup.sh"]
+- ["dracut-modules/partition-info.sh", "/usr/lib/dracut/modules.d/35ocne/partition-info.sh"]
+- ["dracut-modules/grow-rootfs.sh", "/usr/lib/dracut/modules.d/35ocne/grow-rootfs.sh"]
+- ["dracut-modules/grow-rootfs.service", "/usr/lib/dracut/modules.d/35ocne/grow-rootfs.service"]
+- ["dracut-modules/make-rootfs.sh", "/usr/lib/dracut/modules.d/35ocne/make-rootfs.sh"]
+- ["dracut-modules/make-rootfs.service", "/usr/lib/dracut/modules.d/35ocne/make-rootfs.service"]
+- ["dracut-modules/move-gpt-header.sh", "/usr/lib/dracut/modules.d/35ocne/move-gpt-header.sh"]
+- ["dracut-modules/move-gpt-header.service", "/usr/lib/dracut/modules.d/35ocne/move-gpt-header.service"]
+
+postprocess:
+- rm /etc/cni/net.d/100-crio-bridge.conf
+- groupadd -r keepalived_script
+- groupadd sugroup
+- useradd -r -s /sbin/nologin -g keepalived_script -M keepalived_script

--- a/configs/config-1.31/oracle-epel-ol8.repo
+++ b/configs/config-1.31/oracle-epel-ol8.repo
@@ -1,0 +1,14 @@
+[ol8_developer_EPEL]
+name=Oracle Linux $releasever EPEL Packages for Development ($basearch)
+baseurl=https://yum.oracle.com/repo/OracleLinux/OL8/developer/EPEL/$basearch/
+gpgkey=https://yum.oracle.com/RPM-GPG-KEY-oracle-ol8
+gpgcheck=1
+enabled=1
+
+
+[ol8_developer_EPEL_modular]
+name=Oracle Linux $releasever EPEL Modular Packages for Development ($basearch)
+baseurl=https://yum.oracle.com/repo/OracleLinux/OL8/developer/EPEL/modular/$basearch/
+gpgkey=https://yum.oracle.com/RPM-GPG-KEY-oracle-ol8
+gpgcheck=1
+enabled=0

--- a/configs/config-1.31/oracle-linux-ol8.repo
+++ b/configs/config-1.31/oracle-linux-ol8.repo
@@ -1,0 +1,100 @@
+[ol8_baseos_latest]
+name=Oracle Linux 8 BaseOS Latest ($basearch)
+baseurl=https://yum.oracle.com/repo/OracleLinux/OL8/baseos/latest/$basearch/
+gpgkey=https://yum.oracle.com/RPM-GPG-KEY-oracle-ol8
+gpgcheck=1
+enabled=1
+
+[ol8_appstream]
+name=Oracle Linux 8 Application Stream ($basearch)
+baseurl=https://yum.oracle.com/repo/OracleLinux/OL8/appstream/$basearch/
+gpgkey=https://yum.oracle.com/RPM-GPG-KEY-oracle-ol8
+gpgcheck=1
+enabled=1
+
+[ol8_codeready_builder]
+name=Oracle Linux 8 CodeReady Builder ($basearch) - Unsupported
+baseurl=https://yum.oracle.com/repo/OracleLinux/OL8/codeready/builder/$basearch/
+gpgkey=https://yum.oracle.com/RPM-GPG-KEY-oracle-ol8
+gpgcheck=1
+enabled=1
+
+[ol8_distro_builder]
+name=Oracle Linux 8 Distro Builder ($basearch) - Unsupported
+baseurl=https://yum.oracle.com/repo/OracleLinux/OL8/distro/builder/$basearch/
+gpgkey=https://yum.oracle.com/RPM-GPG-KEY-oracle-ol8
+gpgcheck=1
+enabled=1
+
+
+[ol8_u0_baseos_base]
+name=Oracle Linux 8 BaseOS GA ($basearch)
+baseurl=https://yum.oracle.com/repo/OracleLinux/OL8/0/baseos/base/$basearch/
+gpgkey=https://yum.oracle.com/RPM-GPG-KEY-oracle-ol8
+gpgcheck=1
+enabled=0
+
+[ol8_u1_baseos_base]
+name=Oracle Linux 8.1 BaseOS ($basearch)
+baseurl=https://yum.oracle.com/repo/OracleLinux/OL8/1/baseos/base/$basearch/
+gpgkey=https://yum.oracle.com/RPM-GPG-KEY-oracle-ol8
+gpgcheck=1
+enabled=0
+
+[ol8_u2_baseos_base]
+name=Oracle Linux 8.2 BaseOS ($basearch)
+baseurl=https://yum.oracle.com/repo/OracleLinux/OL8/2/baseos/base/$basearch/
+gpgkey=https://yum.oracle.com/RPM-GPG-KEY-oracle-ol8
+gpgcheck=1
+enabled=0
+
+[ol8_u3_baseos_base]
+name=Oracle Linux 8.3 BaseOS ($basearch)
+baseurl=https://yum.oracle.com/repo/OracleLinux/OL8/3/baseos/base/$basearch/
+gpgkey=https://yum.oracle.com/RPM-GPG-KEY-oracle-ol8
+gpgcheck=1
+enabled=0
+
+[ol8_u4_baseos_base]
+name=Oracle Linux 8.4 BaseOS ($basearch)
+baseurl=https://yum.oracle.com/repo/OracleLinux/OL8/4/baseos/base/$basearch/
+gpgkey=https://yum.oracle.com/RPM-GPG-KEY-oracle-ol8
+gpgcheck=1
+enabled=0
+
+[ol8_u5_baseos_base]
+name=Oracle Linux 8.5 BaseOS ($basearch)
+baseurl=https://yum.oracle.com/repo/OracleLinux/OL8/5/baseos/base/$basearch/
+gpgkey=https://yum.oracle.com/RPM-GPG-KEY-oracle-ol8
+gpgcheck=1
+enabled=0
+
+[ol8_u6_baseos_base]
+name=Oracle Linux 8.6 BaseOS ($basearch)
+baseurl=https://yum.oracle.com/repo/OracleLinux/OL8/6/baseos/base/$basearch/
+gpgkey=https://yum.oracle.com/RPM-GPG-KEY-oracle-ol8
+gpgcheck=1
+enabled=0
+
+[ol8_addons]
+name=Oracle Linux 8 Addons ($basearch)
+baseurl=https://yum.oracle.com/repo/OracleLinux/OL8/addons/$basearch/
+gpgkey=https://yum.oracle.com/RPM-GPG-KEY-oracle-ol8
+gpgcheck=1
+enabled=1
+
+[ol8_u4_security_validation]
+name=Oracle Linux $releasever Update 4 ($basearch) Security Validations
+baseurl=https://yum.oracle.com/repo/OracleLinux/OL8/4/security/validation/$basearch/
+gpgkey=https://yum.oracle.com/RPM-GPG-KEY-oracle-ol8
+gpgcheck=1
+enabled=0
+
+[ol8_MODRHCK]
+name=Latest RHCK with fixes from Oracle for Oracle Linux $releasever ($basearch)
+baseurl=https://yum.oracle.com/repo/OracleLinux/OL8/MODRHCK/$basearch/
+gpgkey=https://yum.oracle.com/RPM-GPG-KEY-oracle-ol8
+gpgcheck=1
+priority=20
+enabled=0
+

--- a/configs/config-1.31/oracle-ocne-ol8.repo
+++ b/configs/config-1.31/oracle-ocne-ol8.repo
@@ -1,0 +1,69 @@
+[ol8_olcne12]
+name=Oracle Cloud Native Environment version 1.2 ($basearch)
+baseurl=https://yum.oracle.com/repo/OracleLinux/OL8/olcne12/$basearch/
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-oracle
+gpgcheck=1
+enabled=0
+
+[ol8_olcne13]
+name=Oracle Cloud Native Environment version 1.3 ($basearch)
+baseurl=https://yum.oracle.com/repo/OracleLinux/OL8/olcne13/$basearch/
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-oracle
+gpgcheck=1
+enabled=0
+
+[ol8_olcne14]
+name=Oracle Cloud Native Environment version 1.4 ($basearch)
+baseurl=https://yum.oracle.com/repo/OracleLinux/OL8/olcne14/$basearch/
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-oracle
+gpgcheck=1
+enabled=0
+
+[ol8_olcne15]
+name=Oracle Cloud Native Environment version 1.5 ($basearch)
+baseurl=https://yum.oracle.com/repo/OracleLinux/OL8/olcne15/$basearch/
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-oracle
+gpgcheck=1
+enabled=0
+
+[ol8_olcne16]
+name=Oracle Cloud Native Environment version 1.6 ($basearch)
+baseurl=https://yum.oracle.com/repo/OracleLinux/OL8/olcne16/$basearch/
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-oracle
+gpgcheck=1
+enabled=0
+
+[ol8_olcne17]
+name=Oracle Cloud Native Environment version 1.7 ($basearch)
+baseurl=https://yum.oracle.com/repo/OracleLinux/OL8/olcne17/$basearch/
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-oracle
+gpgcheck=1
+enabled=0
+
+[ol8_olcne18]
+name=Oracle Cloud Native Environment version 1.8 ($basearch)
+baseurl=https://yum.oracle.com/repo/OracleLinux/OL8/olcne18/$basearch/
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-oracle
+gpgcheck=1
+enabled=0
+
+[ol8_olcne19]
+name=Oracle Cloud Native Environment version 1.9 ($basearch)
+baseurl=https://yum.oracle.com/repo/OracleLinux/OL8/olcne19/$basearch/
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-oracle
+gpgcheck=1
+enabled=0
+
+[ol8_ocne]
+name=Oracle Cloud Native Environment version 2.0 ($basearch)
+baseurl=https://yum.oracle.com/repo/OracleLinux/OL8/ocne/$basearch/
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-oracle
+gpgcheck=1
+enabled=0
+
+[ol8_developer_olcne]
+name=Developer Preview for Oracle Cloud Native Environment ($basearch)
+baseurl=https://yum.oracle.com/repo/OracleLinux/OL8/developer/olcne/$basearch/
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-oracle
+gpgcheck=1
+enabled=0

--- a/configs/config-1.31/oracle-software-ol8.repo
+++ b/configs/config-1.31/oracle-software-ol8.repo
@@ -1,0 +1,6 @@
+[ol8_oracle_software]
+name=Oracle Software for Oracle Linux $releasever ($basearch)
+baseurl=https://yum.oracle.com/repo/OracleLinux/OL8/oracle/software/$basearch/
+gpgkey=https://yum.oracle.com/RPM-GPG-KEY-oracle-ol8
+gpgcheck=1
+enabled=1

--- a/configs/config-1.31/oraclelinux-automation-manager-ol8.repo
+++ b/configs/config-1.31/oraclelinux-automation-manager-ol8.repo
@@ -1,0 +1,13 @@
+[ol8_automation]
+name=Oracle Linux Automation Manager 1.0 based on the open source projects Ansible and AWX ($basearch)
+baseurl=https://yum.oracle.com/repo/OracleLinux/OL8/automation/$basearch/
+gpgkey=https://yum.oracle.com/RPM-GPG-KEY-oracle-ol8
+gpgcheck=1
+enabled=1
+
+[ol8_automation2]
+name=Oracle Linux Automation Manager 2.0 based on the open source projects Ansible and AWX ($basearch)
+baseurl=https://yum.oracle.com/repo/OracleLinux/OL8/automation2/$basearch/
+gpgkey=https://yum.oracle.com/RPM-GPG-KEY-oracle-ol8
+gpgcheck=1
+enabled=0

--- a/configs/config-1.31/oraclelinux-developer-ol8.repo
+++ b/configs/config-1.31/oraclelinux-developer-ol8.repo
@@ -1,0 +1,21 @@
+[ol8_developer]
+name=Oracle Linux 8 Development Packages ($basearch)
+baseurl=https://yum.oracle.com/repo/OracleLinux/OL8/developer/$basearch/
+gpgkey=https://yum.oracle.com/RPM-GPG-KEY-oracle-ol8
+gpgcheck=1
+enabled=1
+
+[ol8_developer_UEKR6]
+name=Developer Preview of UEK Release 6 ($basearch)
+baseurl=https://yum.oracle.com/repo/OracleLinux/OL8/developer/UEKR6/$basearch/
+gpgkey=https://yum.oracle.com/RPM-GPG-KEY-oracle-ol8
+gpgcheck=1
+enabled=0
+
+[ol8_developer_UEKR7]
+name=Developer Preview of UEK Release 7 ($basearch)
+baseurl=https://yum.oracle.com/repo/OracleLinux/OL8/developer/UEKR7/$basearch/
+gpgkey=https://yum.oracle.com/RPM-GPG-KEY-oracle-ol8
+gpgcheck=1
+enabled=0
+

--- a/configs/config-1.31/platforms.yaml
+++ b/configs/config-1.31/platforms.yaml
@@ -1,0 +1,9 @@
+x86_64:
+  qemu:
+    grub_commands:
+      - serial --speed=115200
+      - terminal_input serial console
+      - terminal_output serial console
+    kernel_arguments:
+      - console=tty0
+      - console=ttyS0,115200n8

--- a/configs/config-1.31/removals.yaml
+++ b/configs/config-1.31/removals.yaml
@@ -1,0 +1,30 @@
+remove-from-packages:
+- ["python3-libs", ".*"]
+- ["platform-python", ".*"]
+- ["platform-python-pip", ".*"]
+- ["platform-python-setuptools", ".*"]
+- ["python3-setools", ".*"]
+- ["python3-libnmstate", ".*"]
+- ["python3-gobject-base", ".*"]
+- ["python3-pip-wheel", ".*"]
+- ["python3-libselinux", ".*"]
+- ["python3-pyyaml", ".*"]
+- ["python3-setuptools", ".*"]
+- ["python3-libsemanage", ".*"]
+- ["python3-ply", ".*"]
+- ["python3-setuptools-wheel", ".*"]
+- ["python3-audit", ".*"]
+- ["python3-jsonschema", ".*"]
+- ["python3-bind", ".*"]
+- ["python3-varlink", ".*"]
+- ["python3-nispor", ".*"]
+- ["kata-image", ".*"]
+- ["python3-policycoreutils", ".*"]
+- ["policycoreutils-python-utils", ".*"]
+- ["platform-python-3.6", ".*"]
+
+install-langs:
+- en_US
+
+postprocess:
+- localedef --list-archive | grep -v -i ^en | xargs localedef --delete-from-archive

--- a/configs/config-1.31/systemd
+++ b/configs/config-1.31/systemd
@@ -1,0 +1,1 @@
+../common/systemd/

--- a/configs/config-1.31/uek-ol8.repo
+++ b/configs/config-1.31/uek-ol8.repo
@@ -1,0 +1,27 @@
+[ol8_UEKR7]
+name=Latest Unbreakable Enterprise Kernel Release 7 for Oracle Linux $releasever ($basearch)
+baseurl=https://yum.oracle.com/repo/OracleLinux/OL8/UEKR7/$basearch/
+gpgkey=https://yum.oracle.com/RPM-GPG-KEY-oracle-ol8
+gpgcheck=1
+enabled=1
+
+[ol8_UEKR6]
+name=Latest Unbreakable Enterprise Kernel Release 6 for Oracle Linux $releasever ($basearch)
+baseurl=https://yum.oracle.com/repo/OracleLinux/OL8/UEKR6/$basearch/
+gpgkey=https://yum.oracle.com/RPM-GPG-KEY-oracle-ol8
+gpgcheck=1
+enabled=0
+
+[ol8_UEKR7_RDMA]
+name=Oracle Linux 8 UEK7 RDMA ($basearch)
+baseurl=https://yum.oracle.com/repo/OracleLinux/OL8/UEKR7/RDMA/$basearch/
+gpgkey=https://yum.oracle.com/RPM-GPG-KEY-oracle-ol8
+gpgcheck=1
+enabled=0
+
+[ol8_UEKR6_RDMA]
+name=Oracle Linux 8 UEK6 RDMA ($basearch)
+baseurl=https://yum.oracle.com/repo/OracleLinux/OL8/UEKR6/RDMA/$basearch/
+gpgkey=https://yum.oracle.com/RPM-GPG-KEY-oracle-ol8
+gpgcheck=1
+enabled=0

--- a/configs/config-1.31/ux.yaml
+++ b/configs/config-1.31/ux.yaml
@@ -1,0 +1,13 @@
+packages:
+- coreutils
+- file
+- jq
+- less
+- sudo
+- vim-minimal
+- lsof
+- openssh-server
+- bzip2
+- gzip
+- tar
+- xz

--- a/configs/config-1.31/virt-ol8.repo
+++ b/configs/config-1.31/virt-ol8.repo
@@ -1,0 +1,6 @@
+[ol8_kvm_appstream]
+name=Oracle Linux $releasever KVM Application Stream ($basearch)
+baseurl=https://yum.oracle.com/repo/OracleLinux/OL8/kvm/appstream/$basearch/
+gpgkey=https://yum.oracle.com/RPM-GPG-KEY-oracle-ol8
+gpgcheck=1
+enabled=1


### PR DESCRIPTION
Please consider this in combination with https://github.com/oracle-cne/ocne/pull/275

Flannel Test
```
[opc@ol9 ocne]$ ./out/linux_amd64/ocne cluster start --control-plane-nodes 3 --worker-nodes 3
INFO[2025-02-06T01:48:43Z] Creating new Kubernetes cluster with version 1.31 named ocne 

INFO[2025-02-06T01:49:37Z] Waiting for the Kubernetes cluster to be ready: ok 





INFO[2025-02-06T01:49:42Z] Installing core-dns into kube-system: ok 
INFO[2025-02-06T01:49:43Z] Installing kube-proxy into kube-system: ok 
INFO[2025-02-06T01:49:44Z] Installing flannel into kube-flannel: ok 
INFO[2025-02-06T01:49:46Z] Installing ui into ocne-system: ok 
INFO[2025-02-06T01:49:47Z] Installing ocne-catalog into ocne-system: ok 
INFO[2025-02-06T01:49:47Z] Kubernetes cluster was created successfully  
INFO[2025-02-06T01:51:17Z] Waiting for the UI to be ready: ok 

Run the following command to create an authentication token to access the UI:
    KUBECONFIG='/home/opc/.kube/kubeconfig.ocne.local' kubectl create token ui -n ocne-system
Browser window opened, enter 'y' when ready to exit: y

INFO[2025-02-06T01:51:19Z] Post install information:

To access the cluster from the VM host:
    copy /home/opc/.kube/kubeconfig.ocne.vm to that host and run kubectl there
To access the cluster from this system:
    use /home/opc/.kube/kubeconfig.ocne.local
To access the UI, first do kubectl port-forward to allow the browser to access the UI.
Run the following command, then access the UI from the browser using via https://localhost:8443
    kubectl port-forward -n ocne-system service/ui 8443:443
Run the following command to create an authentication token to access the UI:
    kubectl create token ui -n ocne-system 
[opc@ol9 ocne]$ kubectl get nodes
NAME                   STATUS   ROLES           AGE    VERSION
ocne-control-plane-1   Ready    control-plane   109s   v1.31.5+1.el8
ocne-control-plane-2   Ready    control-plane   58s    v1.31.5+1.el8
ocne-control-plane-3   Ready    control-plane   59s    v1.31.5+1.el8
ocne-worker-1          Ready    <none>          60s    v1.31.5+1.el8
ocne-worker-2          Ready    <none>          60s    v1.31.5+1.el8
ocne-worker-3          Ready    <none>          59s    v1.31.5+1.el8
[opc@ol9 ocne]$ kubectl get pods -A
NAMESPACE      NAME                                           READY   STATUS    RESTARTS      AGE
kube-flannel   kube-flannel-ds-85d4h                          1/1     Running   1 (31s ago)   66s
kube-flannel   kube-flannel-ds-bsjm6                          1/1     Running   1 (32s ago)   67s
kube-flannel   kube-flannel-ds-fl5dt                          1/1     Running   1 (31s ago)   67s
kube-flannel   kube-flannel-ds-gqch4                          1/1     Running   1 (30s ago)   65s
kube-flannel   kube-flannel-ds-mzls2                          1/1     Running   1 (28s ago)   66s
kube-flannel   kube-flannel-ds-xm5l8                          1/1     Running   1 (71s ago)   105s
kube-system    coredns-7dcb9db977-99dkk                       0/1     Running   0             107s
kube-system    coredns-7dcb9db977-jg8x9                       0/1     Running   0             107s
kube-system    etcd-ocne-control-plane-1                      1/1     Running   0             115s
kube-system    etcd-ocne-control-plane-2                      1/1     Running   0             52s
kube-system    etcd-ocne-control-plane-3                      1/1     Running   0             66s
kube-system    kube-apiserver-ocne-control-plane-1            1/1     Running   0             115s
kube-system    kube-apiserver-ocne-control-plane-2            1/1     Running   0             62s
kube-system    kube-apiserver-ocne-control-plane-3            1/1     Running   0             66s
kube-system    kube-controller-manager-ocne-control-plane-1   1/1     Running   0             115s
kube-system    kube-controller-manager-ocne-control-plane-2   1/1     Running   0             62s
kube-system    kube-controller-manager-ocne-control-plane-3   1/1     Running   0             66s
kube-system    kube-proxy-454pd                               1/1     Running   0             66s
kube-system    kube-proxy-n6dh5                               1/1     Running   0             65s
kube-system    kube-proxy-p9x7s                               1/1     Running   0             67s
kube-system    kube-proxy-qrp8r                               1/1     Running   0             66s
kube-system    kube-proxy-t79w9                               1/1     Running   0             67s
kube-system    kube-proxy-vk88x                               1/1     Running   0             106s
kube-system    kube-scheduler-ocne-control-plane-1            1/1     Running   0             115s
kube-system    kube-scheduler-ocne-control-plane-2            1/1     Running   0             62s
kube-system    kube-scheduler-ocne-control-plane-3            1/1     Running   0             66s
ocne-system    ocne-catalog-8c94cc49f-48r7f                   1/1     Running   0             102s
ocne-system    ui-6bd5787bb4-fgtxb                            1/1     Running   0             103s

[opc@ol9 cluster]$ ./basic_k8s_test.sh > ~/tmp/1.31_flannel_basic.out 2>&1
[opc@ol9 cluster]$ 
[opc@ol9 cluster]$ tail ~/tmp/1.31_flannel_basic.out 
pod/nginx-7cbcd794fd-7rczz condition met
+ break
+ [[ 0 -eq 1 ]]
+ logInfo 'Successfully ran k8s tests! :)'
++ isFuncDeclared log
++ declare -Ff log
++ echo 1
+ '[' 1 -eq 0 ']'
+ echo Successfully ran k8s 'tests!' ':)'
Successfully ran k8s tests! :)
```

Calico Test
```
[opc@ol9 ocne]$ ./out/linux_amd64/ocne cluster start -c ~/tools/calico-ebpf.yaml --control-plane-nodes 3 --worker-nodes 3
INFO[2025-02-06T02:13:16Z] Creating new Kubernetes cluster with version 1.31 named ocne 

INFO[2025-02-06T02:14:00Z] Waiting for the Kubernetes cluster to be ready: ok 





INFO[2025-02-06T02:14:06Z] Installing core-dns into kube-system: ok 
INFO[2025-02-06T02:14:07Z] Installing kube-proxy into kube-system: ok 
INFO[2025-02-06T02:14:09Z] Installing ui into ocne-system: ok 
INFO[2025-02-06T02:14:10Z] Installing ocne-catalog into ocne-system: ok 
INFO[2025-02-06T02:14:15Z] Installing tigera-operator into tigera-system: ok 
INFO[2025-02-06T02:14:15Z] Kubernetes cluster was created successfully  
INFO[2025-02-06T02:14:15Z] Post install information:

To access the cluster from the VM host:
    copy /home/opc/.kube/kubeconfig.ocne.vm to that host and run kubectl there
To access the cluster from this system:
    use /home/opc/.kube/kubeconfig.ocne.local
To access the UI, first do kubectl port-forward to allow the browser to access the UI.
Run the following command, then access the UI from the browser using via https://localhost:8443
    kubectl port-forward -n ocne-system service/ui 8443:443
Run the following command to create an authentication token to access the UI:
    kubectl create token ui -n ocne-system

[opc@ol9 ocne]$ kubectl get node
NAME                   STATUS   ROLES           AGE     VERSION
ocne-control-plane-1   Ready    control-plane   3m54s   v1.31.5+1.el8
ocne-control-plane-2   Ready    control-plane   3m3s    v1.31.5+1.el8
ocne-control-plane-3   Ready    control-plane   3m4s    v1.31.5+1.el8
ocne-worker-1          Ready    <none>          3m5s    v1.31.5+1.el8
ocne-worker-2          Ready    <none>          3m5s    v1.31.5+1.el8
ocne-worker-3          Ready    <none>          3m6s    v1.31.5+1.el8
[opc@ol9 ocne]$ kubectl get pods -A
NAMESPACE       NAME                                           READY   STATUS    RESTARTS        AGE
calico-system   calico-kube-controllers-68464958d-lsxwg        1/1     Running   0               3m32s
calico-system   calico-node-5zqq6                              1/1     Running   0               3m8s
calico-system   calico-node-84lfs                              0/1     Running   0               3m6s
calico-system   calico-node-8bq2w                              1/1     Running   0               3m9s
calico-system   calico-node-fmktp                              1/1     Running   0               3m32s
calico-system   calico-node-pf4fr                              1/1     Running   0               3m7s
calico-system   calico-node-qxv5h                              1/1     Running   0               3m8s
calico-system   calico-typha-556496b9d7-2g7qn                  1/1     Running   0               3m32s
calico-system   calico-typha-556496b9d7-75fb6                  1/1     Running   0               3m3s
calico-system   calico-typha-556496b9d7-bdmrg                  1/1     Running   0               3m3s
calico-system   csi-node-driver-47ssw                          2/2     Running   0               3m8s
calico-system   csi-node-driver-4krvk                          2/2     Running   0               3m9s
calico-system   csi-node-driver-69q2t                          2/2     Running   0               3m8s
calico-system   csi-node-driver-7mc7h                          2/2     Running   0               3m6s
calico-system   csi-node-driver-8jwdn                          2/2     Running   0               3m7s
calico-system   csi-node-driver-kjcc7                          2/2     Running   0               3m32s
kube-system     coredns-7dcb9db977-75szk                       1/1     Running   0               3m48s
kube-system     coredns-7dcb9db977-dr4r2                       1/1     Running   0               3m48s
kube-system     etcd-ocne-control-plane-1                      1/1     Running   0               3m54s
kube-system     etcd-ocne-control-plane-2                      1/1     Running   0               2m55s
kube-system     etcd-ocne-control-plane-3                      1/1     Running   0               3m7s
kube-system     kube-apiserver-ocne-control-plane-1            1/1     Running   0               3m54s
kube-system     kube-apiserver-ocne-control-plane-2            1/1     Running   1 (2m34s ago)   3m3s
kube-system     kube-apiserver-ocne-control-plane-3            1/1     Running   0               3m7s
kube-system     kube-controller-manager-ocne-control-plane-1   1/1     Running   0               3m54s
kube-system     kube-controller-manager-ocne-control-plane-2   1/1     Running   0               3m3s
kube-system     kube-controller-manager-ocne-control-plane-3   1/1     Running   0               3m7s
kube-system     kube-proxy-gg698                               1/1     Running   0               3m6s
kube-system     kube-proxy-pr6nr                               1/1     Running   0               3m7s
kube-system     kube-proxy-rr4gr                               1/1     Running   0               3m47s
kube-system     kube-proxy-spntc                               1/1     Running   0               3m8s
kube-system     kube-proxy-t2m8t                               1/1     Running   0               3m9s
kube-system     kube-proxy-w8sqz                               1/1     Running   0               3m8s
kube-system     kube-scheduler-ocne-control-plane-1            1/1     Running   0               3m54s
kube-system     kube-scheduler-ocne-control-plane-2            1/1     Running   0               3m3s
kube-system     kube-scheduler-ocne-control-plane-3            1/1     Running   0               3m4s
ocne-system     ocne-catalog-8c94cc49f-khp85                   1/1     Running   0               3m45s
ocne-system     ui-6bd5787bb4-gvkkv                            1/1     Running   0               3m46s
tigera-system   tigera-operator-75b8ccf5fd-thwbj               1/1     Running   0               3m40s

[opc@ol9 cluster]$ ./basic_k8s_test.sh > ~/tmp/1.31_calico_basic.out 2>&1
[opc@ol9 cluster]$ tail ~/tmp/1.31_calico_basic.out 
pod/nginx-7cbcd794fd-2c79j condition met
+ break
+ [[ 0 -eq 1 ]]
+ logInfo 'Successfully ran k8s tests! :)'
++ isFuncDeclared log
++ declare -Ff log
++ echo 1
+ '[' 1 -eq 0 ']'
+ echo Successfully ran k8s 'tests!' ':)'
Successfully ran k8s tests! :)
```



EDIT: as long as we're making a change to skopeo, I'll take the chance to include another requsted change.  This change to ocne-update.sh allows updates to be sourced from arbitrary container image transports.

```
#
# Source updates from an archive.  This allows updates to be served by copying media direclty to
# the filesystem or plug in some removable media and mount it to some location.  It is useful for
# cases where a user does not have a registry available.
#
sh-4.4# cat /etc/ocne/update.yaml 
registry: /var/archive.tar.gz
tag: 1.30
transport: ostree-unverified-image:oci-archive

sh-4.4# journalctl -u ocne-update.service | tail
...
Feb 06 17:42:13 ocne-control-plane-1 systemd[1]: Stopping Update service for OCNE...
Feb 06 17:42:13 ocne-control-plane-1 systemd[1]: ocne-update.service: Succeeded.
Feb 06 17:42:13 ocne-control-plane-1 systemd[1]: Stopped Update service for OCNE.
Feb 06 17:43:17 ocne-control-plane-1 systemd[1]: Started Update service for OCNE.
Feb 06 17:43:17 ocne-control-plane-1 ocne-update.sh[7531]: time="2025-02-06T17:43:17Z" level=fatal msg="Error parsing image name \"oci-archive:/var/archive.tar.gz\": creating temp directory: archive file not found: \"/var/archive.tar.gz\""
Feb 06 17:43:17 ocne-control-plane-1 ocne-update.sh[7505]: Could not inspect image: /var/archive.tar.gz


[root@ol9 1.30]# scp archive.tar.gz dkrasins@192.168.122.228:/home/dkrasins/archive.tar.gz
dkrasins@192.168.122.228's password: 
archive.tar.gz
sh-4.4# mv /home/dkrasins/archive.tar.gz /var/archive.tar.gz

Feb 06 17:45:42 ocne-control-plane-1 systemd[1]: Started Update service for OCNE.
Feb 06 17:45:55 ocne-control-plane-1 ocne-update.sh[8655]: Checking for new content
Feb 06 17:45:55 ocne-control-plane-1 ocne-update.sh[8655]: Image has ostree commit label: d3d7941a8dbe32f9a8cd2ee0645bfe6abe697d34c509bceae8304a902b5ead36
Feb 06 17:45:55 ocne-control-plane-1 ocne-update.sh[8781]: error: No such metadata object d3d7941a8dbe32f9a8cd2ee0645bfe6abe697d34c509bceae8304a902b5ead36.commit
Feb 06 17:45:55 ocne-control-plane-1 ocne-update.sh[8655]: Unencapsulating image
Feb 06 17:45:55 ocne-control-plane-1 ocne-update.sh[8782]: Pulling manifest: ostree-unverified-image:oci-archive:/var/archive.tar.gz
Feb 06 17:46:07 ocne-control-plane-1 ocne-update.sh[8782]: Importing: ostree-unverified-image:oci-archive:/var/archive.tar.gz (digest: sha256:b02eb50e7c80dee546fd43ad0c814053a5869dbf57dd86602f772aa57c84b4c7)
Feb 06 17:46:07 ocne-control-plane-1 ocne-update.sh[8782]: ostree chunk layers stored: 0 needed: 65 (2.4 GB)
Feb 06 17:46:07 ocne-control-plane-1 ocne-update.sh[8782]: Fetching ostree chunk sha256:37cb2f7a5c26 (867.1 MB)
Feb 06 17:46:23 ocne-control-plane-1 ocne-update.sh[8782]: Fetched ostree chunk sha256:37cb2f7a5c26


------------------

#
# Use a more verbose syntax for specifying a registry
#
sh-4.4# cat /etc/ocne/update.yaml 
registry: container-registry.oracle.com/olcne/ock-ostree
tag: 1.30
transport: ostree-unverified-image:docker://

sh-4.4# systemctl start ocne-update.service

Feb 06 17:49:24 ocne-control-plane-1 systemd[1]: Started Update service for OCNE.
Feb 06 17:49:27 ocne-control-plane-1 ocne-update.sh[10288]: Checking for new content
Feb 06 17:49:27 ocne-control-plane-1 ocne-update.sh[10288]: Image has ostree commit label: 0a83ddf032c18c33d8c322a342809726d2af1b1b94358bea90fdf5e3e1a56a12
Feb 06 17:49:27 ocne-control-plane-1 ocne-update.sh[10356]: error: No such metadata object 0a83ddf032c18c33d8c322a342809726d2af1b1b94358bea90fdf5e3e1a56a12.commit
Feb 06 17:49:27 ocne-control-plane-1 ocne-update.sh[10288]: Unencapsulating image
Feb 06 17:49:27 ocne-control-plane-1 ocne-update.sh[10357]: Pulling manifest: ostree-unverified-image:docker://container-registry.oracle.com/olcne/ock-ostree:1.30
Feb 06 17:49:29 ocne-control-plane-1 ocne-update.sh[10357]: Importing: ostree-unverified-image:docker://container-registry.oracle.com/olcne/ock-ostree:1.30 (digest: sha256:f5ba5cf4a28e21970345ef0f3e661a48e2542e9d49d76a814b053886f87c1c35)
Feb 06 17:49:29 ocne-control-plane-1 ocne-update.sh[10357]: ostree chunk layers stored: 0 needed: 65 (2.5 GB)
Feb 06 17:49:29 ocne-control-plane-1 ocne-update.sh[10357]: Fetching ostree chunk sha256:3592921312f4 (945.5 MB)

------------------

#
# Use the short syntax for the same
#
sh-4.4# cat /etc/ocne/update.yaml 
registry: container-registry.oracle.com/olcne/ock-ostree
tag: 1.29
transport: ostree-unverified-registry

sh-4.4# systemctl start ocne-update.service

Feb 06 17:59:28 ocne-control-plane-1 systemd[1]: Started Update service for OCNE.
Feb 06 17:59:32 ocne-control-plane-1 ocne-update.sh[14820]: Checking for new content
Feb 06 17:59:32 ocne-control-plane-1 ocne-update.sh[14820]: Image has ostree commit label: f33923ce9ddc8bd5ad9978f85afbb77edc3798ea3784897248d0ebfe9b89d3b3
Feb 06 17:59:32 ocne-control-plane-1 ocne-update.sh[14887]: error: No such metadata object f33923ce9ddc8bd5ad9978f85afbb77edc3798ea3784897248d0ebfe9b89d3b3.commit
Feb 06 17:59:32 ocne-control-plane-1 ocne-update.sh[14820]: Unencapsulating image
Feb 06 17:59:32 ocne-control-plane-1 ocne-update.sh[14888]: Pulling manifest: ostree-unverified-image:docker://container-registry.oracle.com/olcne/ock-ostree:1.29
Feb 06 17:59:34 ocne-control-plane-1 ocne-update.sh[14888]: Importing: ostree-unverified-image:docker://container-registry.oracle.com/olcne/ock-ostree:1.29 (digest: sha256:10d15c587f9f6d3118faf3461ecc9ab120f824316ec25bde6e47892a51d16fd6)
Feb 06 17:59:34 ocne-control-plane-1 ocne-update.sh[14888]: ostree chunk layers stored: 29 needed: 36 (1.9 GB)
Feb 06 17:59:34 ocne-control-plane-1 ocne-update.sh[14888]: Fetching ostree chunk sha256:07a2e1f7fa81 (942.8 MB)

```