### PR TITLE
Remove "kubeadm upgrade" from the self-update process

### DIFF
--- a/configs/common/systemd/kube-update.conf
+++ b/configs/common/systemd/kube-update.conf
@@ -1,2 +1,0 @@
-[Service]
-ExecStartPre=/etc/ocne/ocne-kube-update.sh

--- a/configs/common/systemd/ocne-kubeadm-upgrade.sh
+++ b/configs/common/systemd/ocne-kubeadm-upgrade.sh
@@ -1,49 +1,5 @@
 #! /bin/bash
 #
-# Copyright (c) 2024, Oracle and/or its affiliates.
+# Copyright (c) 2025, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
-set -x
-
-# Run the appropriate form of "kubeadm upgrade" based on whether a control-plan or worker node
-upgrade() {
-  while true; do
-    sleep 30s
-    if ! KUBECONFIG=/etc/kubernetes/kubelet.conf kubectl get nodes; then
-        echo API Server not available yet
-        continue
-    fi
-
-    if KUBECONFIG=/etc/kubernetes/kubelet.conf kubectl get node $HOSTNAME --show-labels | grep -q "kubernetes.io/control-plane"; then
-      # Upgrade the control-plane node
-      kubeadm upgrade apply -y "$VERSION" --ignore-preflight-errors "CoreDNSUnsupportedPlugins,CoreDNSMigration,CreateJob" -v5
-    else
-      # Upgrade the worker node
-      kubeadm upgrade node
-    fi
-    break
-  done
-}
-
-# Determine if an kubeadm upgrade is required.
-VERSION=$(kubeadm version -o yaml | yq eval .clientVersion.gitVersion | cut -d+ -f1)
-VERSION_FILE=/var/ocne/kubeadm-version
-mkdir -p "$(dirname $VERSION_FILE)"
-if [ ! -f "$VERSION_FILE" ]; then
-	echo "Version file does not exist yet, no upgrade required."
-	echo "Noting current version as reference for future upgrades."
-	echo "$VERSION" > "$VERSION_FILE"
-	exit 0
-fi
-
-OLD_VERSION="$(< ${VERSION_FILE})"
-OLDEST_VERSION=$(printf "%s\n%s" "${OLD_VERSION}" "${VERSION}" | sort -V | head -1)
-
-# If the oldest version is not the same as the current version, then
-# it is necessary to update
-if [ "$OLDEST_VERSION" = "$VERSION" ]; then
-	echo "Current version is the same as the previous version.  There is no upgrade to perform."
-	exit 0
-fi
-
-upgrade
-echo "$VERSION" > "$VERSION_FILE"
+exit 0

--- a/configs/config-1.26/ocne.yaml
+++ b/configs/config-1.26/ocne.yaml
@@ -29,7 +29,6 @@ add-files:
 - ["systemd/ocne-kubeadm-upgrade.sh", "/etc/ocne/ocne-kubeadm-upgrade.sh"]
 - ["systemd/ocne-prune.service", "/usr/lib/systemd/system/ocne-prune.service"]
 - ["systemd/ocne-prune.sh", "/etc/ocne/ocne-prune.sh"]
-- ["systemd/kube-update.conf", "/etc/systemd/system/kubelet.service.d/kube-update.conf"]
 - ["files/crio.conf", "/etc/crio/crio.conf"]
 - ["files/kubeadm-default.conf", "/etc/ocne/kubeadm-default.conf"]
 - ["files/check-node-health.sh", "/usr/bin/check-node-health.sh"]

--- a/configs/config-1.27/ocne.yaml
+++ b/configs/config-1.27/ocne.yaml
@@ -29,7 +29,6 @@ add-files:
 - ["systemd/ocne-kubeadm-upgrade.sh", "/etc/ocne/ocne-kubeadm-upgrade.sh"]
 - ["systemd/ocne-prune.service", "/usr/lib/systemd/system/ocne-prune.service"]
 - ["systemd/ocne-prune.sh", "/etc/ocne/ocne-prune.sh"]
-- ["systemd/kube-update.conf", "/etc/systemd/system/kubelet.service.d/kube-update.conf"]
 - ["files/crio.conf", "/etc/crio/crio.conf"]
 - ["files/kubeadm-default.conf", "/etc/ocne/kubeadm-default.conf"]
 - ["files/check-node-health.sh", "/usr/bin/check-node-health.sh"]

--- a/configs/config-1.28/ocne.yaml
+++ b/configs/config-1.28/ocne.yaml
@@ -30,7 +30,6 @@ add-files:
 - ["systemd/ocne-kubeadm-upgrade.sh", "/etc/ocne/ocne-kubeadm-upgrade.sh"]
 - ["systemd/ocne-prune.service", "/usr/lib/systemd/system/ocne-prune.service"]
 - ["systemd/ocne-prune.sh", "/etc/ocne/ocne-prune.sh"]
-- ["systemd/kube-update.conf", "/etc/systemd/system/kubelet.service.d/kube-update.conf"]
 - ["files/crio.conf", "/etc/crio/crio.conf"]
 - ["files/kubeadm-default.conf", "/etc/ocne/kubeadm-default.conf"]
 - ["files/check-node-health.sh", "/usr/bin/check-node-health.sh"]

--- a/configs/config-1.29/ocne.yaml
+++ b/configs/config-1.29/ocne.yaml
@@ -29,7 +29,6 @@ add-files:
 - ["systemd/ocne-kubeadm-upgrade.sh", "/etc/ocne/ocne-kubeadm-upgrade.sh"]
 - ["systemd/ocne-prune.service", "/usr/lib/systemd/system/ocne-prune.service"]
 - ["systemd/ocne-prune.sh", "/etc/ocne/ocne-prune.sh"]
-- ["systemd/kube-update.conf", "/etc/systemd/system/kubelet.service.d/kube-update.conf"]
 - ["files/crio.conf", "/etc/crio/crio.conf"]
 - ["files/kubeadm-default.conf", "/etc/ocne/kubeadm-default.conf"]
 - ["files/check-node-health.sh", "/usr/bin/check-node-health.sh"]

--- a/configs/config-1.30/ocne.yaml
+++ b/configs/config-1.30/ocne.yaml
@@ -29,7 +29,6 @@ add-files:
 - ["systemd/ocne-kubeadm-upgrade.sh", "/etc/ocne/ocne-kubeadm-upgrade.sh"]
 - ["systemd/ocne-prune.service", "/usr/lib/systemd/system/ocne-prune.service"]
 - ["systemd/ocne-prune.sh", "/etc/ocne/ocne-prune.sh"]
-- ["systemd/kube-update.conf", "/etc/systemd/system/kubelet.service.d/kube-update.conf"]
 - ["files/crio.conf", "/etc/crio/crio.conf"]
 - ["files/kubeadm-default.conf", "/etc/ocne/kubeadm-default.conf"]
 - ["files/check-node-health.sh", "/usr/bin/check-node-health.sh"]

--- a/configs/config-1.31/ocne.yaml
+++ b/configs/config-1.31/ocne.yaml
@@ -29,7 +29,6 @@ add-files:
 - ["systemd/ocne-kubeadm-upgrade.sh", "/etc/ocne/ocne-kubeadm-upgrade.sh"]
 - ["systemd/ocne-prune.service", "/usr/lib/systemd/system/ocne-prune.service"]
 - ["systemd/ocne-prune.sh", "/etc/ocne/ocne-prune.sh"]
-- ["systemd/kube-update.conf", "/etc/systemd/system/kubelet.service.d/kube-update.conf"]
 - ["files/crio.conf", "/etc/crio/crio.conf"]
 - ["files/kubeadm-default.conf", "/etc/ocne/kubeadm-default.conf"]
 - ["files/check-node-health.sh", "/usr/bin/check-node-health.sh"]


### PR DESCRIPTION
The call to "kubeadm upgrade" has side effects that extend to the entire cluster rather than just the node being updated.  It needs to be removed.  The script that called "kubeadm upgrade" now has nothing to do.  It no longer needs to be specified as an exec command on kubelet.service, so that drop-in can be removed entirely.  The script itself cannot yet be removed.  The ignition configuration laid down the CLI must disable "kubeadm upgrade" as well to account for existing deployments of Kubernetes.  By overwriting that file, ostree will preserve the overwrite going forward.  In order for the file to actually be removed from existing cluster nodes, that diff must be eliminated.  Future versions for some time T must include the file with the same contents as in https://github.com/oracle-cne/ocne/blob/main/pkg/cluster/update/constants.go#L9.  That way, the file can be removed from OCK and will actually be removed from the node.