### PR TITLE
Tolerate unformatted disks in initrd

### DIFF
--- a/configs/common/dracut-modules/grow-rootfs.sh
+++ b/configs/common/dracut-modules/grow-rootfs.sh
@@ -5,8 +5,15 @@
 set -e
 set -x
 
-ROOT=."/dev/disk/by-label/root"
-DEVICES=$(/usr/sbin/partition-info "${ROOT}")
+# Try to find the device that holds the root filesystem, if one exists.
+# If one does not exist, exit with success.  It is possible that the root
+# partition is not yet available for some reason.
+ROOT="/dev/disk/by-label/root"
+DEVICES=
+if ! DEVICES=$(/usr/sbin/partition-info "${ROOT}"); then
+	echo "Root disk does not exist"
+	exit 0
+fi
 
 read -r -a ROOT_DEVICES <<< "$DEVICES"
 DISK="${ROOT_DEVICES[0]}"

--- a/configs/common/dracut-modules/make-rootfs.sh
+++ b/configs/common/dracut-modules/make-rootfs.sh
@@ -15,6 +15,7 @@ mkdir -p /sysroot/var/ocne/cni/bin
 mkdir -p /sysroot/var/ocne/cni/bin-workdir
 
 setfiles -vFi0 -r /sysroot /sysroot/etc/selinux/targeted/contexts/files/file_contexts /sysroot/var
+setfiles -vFi0 -r /sysroot /sysroot/etc/selinux/targeted/contexts/files/file_contexts /sysroot/etc
 
 # Work around https://github.com/coreos/rpm-ostree/issues/29
 grep -E '^wheel:' /sysroot/usr/lib/group >> /sysroot/etc/group

--- a/configs/common/dracut-modules/move-gpt-header.sh
+++ b/configs/common/dracut-modules/move-gpt-header.sh
@@ -5,8 +5,15 @@
 set -e
 set -x
 
-ROOT=."/dev/disk/by-label/root"
-DEVICES=$(/usr/sbin/partition-info "${ROOT}")
+# Try to find the device that holds the root filesystem, if one exists.
+# If one does not exist, exit with success.  It is possible that the root
+# partition is not yet available for some reason.
+ROOT="/dev/disk/by-label/root"
+DEVICES=
+if ! DEVICES=$(/usr/sbin/partition-info "${ROOT}"); then
+	echo "Root disk does not exist"
+	exit 0
+fi
 
 read -r -a ROOT_DEVICES <<< "$DEVICES"
 DISK="${ROOT_DEVICES[0]}"

--- a/configs/common/dracut-modules/partition-info.sh
+++ b/configs/common/dracut-modules/partition-info.sh
@@ -32,7 +32,7 @@ while [ $i -le 20 ]; do
 	sleep 1
 done
 
-if [ $i -eq 20 ]; then
+if [ $i -gt 20 ]; then
 	echo "Timed out waiting for root device"
 	exit 1
 fi

--- a/configs/config-1.32/manifest.yaml
+++ b/configs/config-1.32/manifest.yaml
@@ -1,5 +1,5 @@
 ref: ock
-automatic-version-prefix: "1.31"
+automatic-version-prefix: "1.32"
 
 documentation: false
 boot-location: modules


### PR DESCRIPTION
Tolerating unformatted disks in the initrd allows OCK to install itself via an ISO.

This also fixes an unrelated issue where OCK 1.32 has the wrong version number in Grub.