### PR TITLE
Add a service that starts before ocne.service and kubeadm.service to enforce a real hostname

### DIFF
--- a/configs/common/systemd/80-ocne.preset
+++ b/configs/common/systemd/80-ocne.preset
@@ -4,5 +4,6 @@ enable ocne-prune.service
 enable ocne-update.service
 enable ocne-image-cleanup.service
 enable usr-lib-opt-cni-bin.mount
+enable wait-for-hostname.service
 disable ocne-nginx.service
 disable keepalived.service

--- a/configs/common/systemd/wait-for-hostname
+++ b/configs/common/systemd/wait-for-hostname
@@ -1,0 +1,9 @@
+#! /bin/bash
+
+while true; do
+	sleep 1
+	HOSTNAME=$(hostname)
+	echo "$HOSTNAME" | grep '^localhost$' && continue
+	echo "$HOSTNAME" | grep '^localhost.localdomain$' && continue
+	exit 0
+done

--- a/configs/common/systemd/wait-for-hostname
+++ b/configs/common/systemd/wait-for-hostname
@@ -1,5 +1,9 @@
 #! /bin/bash
 
+HOSTNAME=$(hostname)
+echo "$HOSTNAME" | grep '^localhost$' || exit 0
+echo "$HOSTNAME" | grep '^localhost.localdomain$' || exit 0
+
 while true; do
 	sleep 1
 	HOSTNAME=$(hostname)

--- a/configs/common/systemd/wait-for-hostname.service
+++ b/configs/common/systemd/wait-for-hostname.service
@@ -1,6 +1,8 @@
 [Unit]
 Description=Wait for a real hostname to be set
 Before=network-online.target
+Before=kubeadm.service
+Before=ocne.service
 
 [Service]
 Type=oneshot

--- a/configs/common/systemd/wait-for-hostname.service
+++ b/configs/common/systemd/wait-for-hostname.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=Wait for a real hostname to be set
+Before=network-online.target
+
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/wait-for-hostname
+RemainAfterExit=yes
+
+[Install]
+WantedBy=network-online.target

--- a/configs/config-1.26/ocne.yaml
+++ b/configs/config-1.26/ocne.yaml
@@ -30,6 +30,8 @@ add-files:
 - ["systemd/ocne-prune.service", "/usr/lib/systemd/system/ocne-prune.service"]
 - ["systemd/ocne-prune.sh", "/etc/ocne/ocne-prune.sh"]
 - ["systemd/kube-update.conf", "/etc/systemd/system/kubelet.service.d/kube-update.conf"]
+- ["systemd/wait-for-hostname.service", "/usr/lib/systemd/system/wait-for-hostname.service"]
+- ["systemd/wait-for-hostname", "/usr/bin/wait-for-hostname"]
 - ["files/crio.conf", "/etc/crio/crio.conf"]
 - ["files/kubeadm-default.conf", "/etc/ocne/kubeadm-default.conf"]
 - ["files/check-node-health.sh", "/usr/bin/check-node-health.sh"]

--- a/configs/config-1.27/ocne.yaml
+++ b/configs/config-1.27/ocne.yaml
@@ -30,6 +30,8 @@ add-files:
 - ["systemd/ocne-prune.service", "/usr/lib/systemd/system/ocne-prune.service"]
 - ["systemd/ocne-prune.sh", "/etc/ocne/ocne-prune.sh"]
 - ["systemd/kube-update.conf", "/etc/systemd/system/kubelet.service.d/kube-update.conf"]
+- ["systemd/wait-for-hostname.service", "/usr/lib/systemd/system/wait-for-hostname.service"]
+- ["systemd/wait-for-hostname", "/usr/bin/wait-for-hostname"]
 - ["files/crio.conf", "/etc/crio/crio.conf"]
 - ["files/kubeadm-default.conf", "/etc/ocne/kubeadm-default.conf"]
 - ["files/check-node-health.sh", "/usr/bin/check-node-health.sh"]

--- a/configs/config-1.28/ocne.yaml
+++ b/configs/config-1.28/ocne.yaml
@@ -31,6 +31,8 @@ add-files:
 - ["systemd/ocne-prune.service", "/usr/lib/systemd/system/ocne-prune.service"]
 - ["systemd/ocne-prune.sh", "/etc/ocne/ocne-prune.sh"]
 - ["systemd/kube-update.conf", "/etc/systemd/system/kubelet.service.d/kube-update.conf"]
+- ["systemd/wait-for-hostname.service", "/usr/lib/systemd/system/wait-for-hostname.service"]
+- ["systemd/wait-for-hostname", "/usr/bin/wait-for-hostname"]
 - ["files/crio.conf", "/etc/crio/crio.conf"]
 - ["files/kubeadm-default.conf", "/etc/ocne/kubeadm-default.conf"]
 - ["files/check-node-health.sh", "/usr/bin/check-node-health.sh"]

--- a/configs/config-1.29/ocne.yaml
+++ b/configs/config-1.29/ocne.yaml
@@ -29,6 +29,8 @@ add-files:
 - ["systemd/ocne-kubeadm-upgrade.sh", "/etc/ocne/ocne-kubeadm-upgrade.sh"]
 - ["systemd/ocne-prune.service", "/usr/lib/systemd/system/ocne-prune.service"]
 - ["systemd/ocne-prune.sh", "/etc/ocne/ocne-prune.sh"]
+- ["systemd/wait-for-hostname.service", "/usr/lib/systemd/system/wait-for-hostname.service"]
+- ["systemd/wait-for-hostname", "/usr/bin/wait-for-hostname"]
 - ["systemd/kube-update.conf", "/etc/systemd/system/kubelet.service.d/kube-update.conf"]
 - ["files/crio.conf", "/etc/crio/crio.conf"]
 - ["files/kubeadm-default.conf", "/etc/ocne/kubeadm-default.conf"]

--- a/configs/config-1.30/ocne.yaml
+++ b/configs/config-1.30/ocne.yaml
@@ -33,6 +33,8 @@ add-files:
 - ["systemd/start_ocne_nginx", "/usr/bin/start_ocne_nginx"]
 - ["systemd/nginx.service", "/usr/lib/systemd/system/ocne-nginx.service"]
 - ["systemd/nginx-image.conf", "/etc/systemd/system/ocne-nginx.service.d/image.conf"]
+- ["systemd/wait-for-hostname.service", "/usr/lib/systemd/system/wait-for-hostname.service"]
+- ["systemd/wait-for-hostname", "/usr/bin/wait-for-hostname"]
 - ["files/crio.conf", "/etc/crio/crio.conf"]
 - ["files/kubeadm-default.conf", "/etc/ocne/kubeadm-default.conf"]
 - ["files/check-node-health.sh", "/usr/bin/check-node-health.sh"]

--- a/configs/config-1.31/ocne.yaml
+++ b/configs/config-1.31/ocne.yaml
@@ -33,6 +33,8 @@ add-files:
 - ["systemd/start_ocne_nginx", "/usr/bin/start_ocne_nginx"]
 - ["systemd/nginx.service", "/usr/lib/systemd/system/ocne-nginx.service"]
 - ["systemd/nginx-image.conf", "/etc/systemd/system/ocne-nginx.service.d/image.conf"]
+- ["systemd/wait-for-hostname.service", "/usr/lib/systemd/system/wait-for-hostname.service"]
+- ["systemd/wait-for-hostname", "/usr/bin/wait-for-hostname"]
 - ["files/crio.conf", "/etc/crio/crio.conf"]
 - ["files/kubeadm-default.conf", "/etc/ocne/kubeadm-default.conf"]
 - ["files/check-node-health.sh", "/usr/bin/check-node-health.sh"]

--- a/configs/config-1.32/ocne.yaml
+++ b/configs/config-1.32/ocne.yaml
@@ -33,6 +33,8 @@ add-files:
 - ["systemd/start_ocne_nginx", "/usr/bin/start_ocne_nginx"]
 - ["systemd/nginx.service", "/usr/lib/systemd/system/ocne-nginx.service"]
 - ["systemd/nginx-image.conf", "/etc/systemd/system/ocne-nginx.service.d/image.conf"]
+- ["systemd/wait-for-hostname.service", "/usr/lib/systemd/system/wait-for-hostname.service"]
+- ["systemd/wait-for-hostname", "/usr/bin/wait-for-hostname"]
 - ["files/crio.conf", "/etc/crio/crio.conf"]
 - ["files/kubeadm-default.conf", "/etc/ocne/kubeadm-default.conf"]
 - ["files/check-node-health.sh", "/usr/bin/check-node-health.sh"]

--- a/configs/config-1.33/ocne.yaml
+++ b/configs/config-1.33/ocne.yaml
@@ -35,6 +35,8 @@ add-files:
 - ["systemd/start_ocne_nginx", "/usr/bin/start_ocne_nginx"]
 - ["systemd/nginx.service", "/usr/lib/systemd/system/ocne-nginx.service"]
 - ["systemd/nginx-image.conf", "/etc/systemd/system/ocne-nginx.service.d/image.conf"]
+- ["systemd/wait-for-hostname.service", "/usr/lib/systemd/system/wait-for-hostname.service"]
+- ["systemd/wait-for-hostname", "/usr/bin/wait-for-hostname"]
 - ["files/crio.conf", "/etc/crio/crio.conf"]
 - ["files/kubeadm-default.conf", "/etc/ocne/kubeadm-default.conf"]
 - ["files/check-node-health.sh", "/usr/bin/check-node-health.sh"]

--- a/configs/config-1.33/oracle-ocne-ol8.repo
+++ b/configs/config-1.33/oracle-ocne-ol8.repo
@@ -60,6 +60,7 @@ baseurl=https://yum.oracle.com/repo/OracleLinux/OL8/ocne/$basearch/
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-oracle
 gpgcheck=1
 enabled=0
+module_hotfixes=1
 
 [ol8_developer_olcne]
 name=Developer Preview for Oracle Cloud Native Environment ($basearch)

--- a/configs/config-1.33/oracle-ocne-ol8.repo
+++ b/configs/config-1.33/oracle-ocne-ol8.repo
@@ -59,7 +59,6 @@ name=Oracle Cloud Native Environment version 2.0 ($basearch)
 baseurl=https://yum.oracle.com/repo/OracleLinux/OL8/ocne/$basearch/
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-oracle
 gpgcheck=1
-module_hotfixes=1
 enabled=0
 module_hotfixes=1
 


### PR DESCRIPTION
There is not really a valid use case for having `localhost.localdomain` as the hostname for a cluster, even for a single node throwaway cluster.  Adding a service that starts before any cluster init/join operations ensure that a real hostname is available, even in cases where `network-online.target` is reached before a hostname is assigned.